### PR TITLE
Add items

### DIFF
--- a/src/main/java/ru/spb/hse/roguelike/Main.java
+++ b/src/main/java/ru/spb/hse/roguelike/Main.java
@@ -5,6 +5,7 @@ import ru.spb.hse.roguelike.model.MapGeneratorException;
 import ru.spb.hse.roguelike.model.GameModel;
 import ru.spb.hse.roguelike.model.Generator;
 import ru.spb.hse.roguelike.model.UnknownObjectException;
+import ru.spb.hse.roguelike.model.map.GameCellException;
 import ru.spb.hse.roguelike.model.map.GameMapCellType;
 import ru.spb.hse.roguelike.view.TerminalView;
 import ru.spb.hse.roguelike.view.View;
@@ -14,7 +15,7 @@ import java.io.IOException;
 import java.io.FileNotFoundException;
 
 public class Main {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws GameCellException {
         try {
             Generator generator = new Generator();
             GameModel model;

--- a/src/main/java/ru/spb/hse/roguelike/Main.java
+++ b/src/main/java/ru/spb/hse/roguelike/Main.java
@@ -7,6 +7,7 @@ import ru.spb.hse.roguelike.model.Generator;
 import ru.spb.hse.roguelike.model.UnknownObjectException;
 import ru.spb.hse.roguelike.model.map.GameCellException;
 import ru.spb.hse.roguelike.model.map.GameMapCellType;
+import ru.spb.hse.roguelike.model.object.items.CannotApplyFoodMultipleTimesException;
 import ru.spb.hse.roguelike.view.TerminalView;
 import ru.spb.hse.roguelike.view.View;
 
@@ -15,7 +16,7 @@ import java.io.IOException;
 import java.io.FileNotFoundException;
 
 public class Main {
-    public static void main(String[] args) throws GameCellException {
+    public static void main(String[] args) throws GameCellException, CannotApplyFoodMultipleTimesException {
         try {
             Generator generator = new Generator();
             GameModel model;

--- a/src/main/java/ru/spb/hse/roguelike/controler/Controller.java
+++ b/src/main/java/ru/spb/hse/roguelike/controler/Controller.java
@@ -82,43 +82,46 @@ public class Controller {
         return true;
     }
 
-    boolean executeCommand() throws ViewException, UnknownObjectException, GameCellException {
+    boolean executeCommand() throws ViewException, UnknownObjectException {
         Command command = view.readCommand();
         if (command == null) {
             return true;
         }
-        switch (command) {
-            case LEFT: {
-                return handleMove(0, -1);
-            }
-            case RIGHT: {
-                return handleMove(0, 1);
-            }
-            case UP: {
-                return handleMove(-1, 0);
-            }
-            case DOWN: {
-                return handleMove(1, 0);
-            }
-            case CONFUSE_MOBS: {
-                gameModel.confuseMobs();
-                return true;
-            }
-            case APPLY_ITEM: {
-                try {
-                    gameModel.makeCharacterApplyItem();
-                } catch (CannotPickItemException ignored) {
-                    // TODO: APPLY_ITEM or DROP_WEARABLE should not count as a move if it didn't succeed
+        try {
+            switch (command) {
+                case LEFT: {
+                    return handleMove(0, -1);
                 }
-                return true;
-            }
-            case DROP_WEARABLE: {
-                try {
-                    gameModel.makeCharacterDropTopWearable();
-                } catch (CannotDropWearableException ignored) {
+                case RIGHT: {
+                    return handleMove(0, 1);
                 }
-                return true;
+                case UP: {
+                    return handleMove(-1, 0);
+                }
+                case DOWN: {
+                    return handleMove(1, 0);
+                }
+                case CONFUSE_MOBS: {
+                    gameModel.confuseMobs();
+                    return true;
+                }
+                case APPLY_ITEM: {
+                    try {
+                        gameModel.makeCharacterApplyItem();
+                    } catch (CannotPickItemException ignored) {
+                        // TODO: APPLY_ITEM or DROP_WEARABLE should not count as a move if it didn't succeed
+                    }
+                    return true;
+                }
+                case DROP_WEARABLE: {
+                    try {
+                        gameModel.makeCharacterDropTopWearable();
+                    } catch (CannotDropWearableException ignored) {
+                    }
+                    return true;
+                }
             }
+        } catch (GameCellException ignored) {
         }
         return true;
     }

--- a/src/main/java/ru/spb/hse/roguelike/controler/Controller.java
+++ b/src/main/java/ru/spb/hse/roguelike/controler/Controller.java
@@ -12,6 +12,7 @@ import ru.spb.hse.roguelike.model.UnknownObjectException;
 import ru.spb.hse.roguelike.model.map.GameCellException;
 import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
 import ru.spb.hse.roguelike.model.object.alive.NonPlayerCharacter;
+import ru.spb.hse.roguelike.model.object.items.CannotApplyFoodMultipleTimesException;
 import ru.spb.hse.roguelike.view.Command;
 import ru.spb.hse.roguelike.view.View;
 import ru.spb.hse.roguelike.view.ViewException;
@@ -45,7 +46,7 @@ public class Controller {
     /**
      * Runs the read commands until game ends.
      */
-    public void runGame() throws IOException, InterruptedException, UnknownObjectException, GameCellException {
+    public void runGame() throws IOException, InterruptedException, UnknownObjectException, GameCellException, CannotApplyFoodMultipleTimesException {
         while (executeCommand() && moveMobs()) ;
         view.end();
     }
@@ -82,7 +83,7 @@ public class Controller {
         return true;
     }
 
-    boolean executeCommand() throws ViewException, UnknownObjectException {
+    boolean executeCommand() throws ViewException, UnknownObjectException, CannotApplyFoodMultipleTimesException {
         Command command = view.readCommand();
         if (command == null) {
             return true;

--- a/src/main/java/ru/spb/hse/roguelike/controler/Controller.java
+++ b/src/main/java/ru/spb/hse/roguelike/controler/Controller.java
@@ -130,10 +130,6 @@ public class Controller {
         Point point = oldPoint.add(diff);
         if (moved) {
             view.showChanges(oldPoint);
-            if (gameModel.getCell(point).hasItem() &&
-                    gameModel.getCharacterInventory().size() != gameModel.getMaxInventorySize()) {
-                gameModel.addItem(gameModel.takeCellItem(point));
-            }
             view.showChanges(point);
         } else {
             if (gameModel.getCell(point) != null &&

--- a/src/main/java/ru/spb/hse/roguelike/model/CannotDropWearableException.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/CannotDropWearableException.java
@@ -1,4 +1,7 @@
 package ru.spb.hse.roguelike.model;
 
 public class CannotDropWearableException extends Exception {
+    public CannotDropWearableException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/CannotDropWearableException.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/CannotDropWearableException.java
@@ -1,0 +1,4 @@
+package ru.spb.hse.roguelike.model;
+
+public class CannotDropWearableException extends Exception {
+}

--- a/src/main/java/ru/spb/hse/roguelike/model/CannotPickItemException.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/CannotPickItemException.java
@@ -1,0 +1,4 @@
+package ru.spb.hse.roguelike.model;
+
+public class CannotPickItemException extends Exception {
+}

--- a/src/main/java/ru/spb/hse/roguelike/model/GameModel.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/GameModel.java
@@ -180,13 +180,17 @@ public class GameModel {
         item.apply(gameCharacter);
     }
 
-    public void makeCharacterDropTopWearable() throws CannotDropWearableException, GameCellException {
+    public void makeCharacterDropTopWearable() throws CannotDropWearableException {
         if (!gameCharacter.hasWearable()) {
-            throw new CannotDropWearableException();
+            throw new CannotDropWearableException("The character doesn't have any items to drop");
         }
         Wearable wearable = gameCharacter.peekWearable();
-        wearable.unapply(gameCharacter);
         GameCell cell = getCell(aliveObjectToPoint.get(gameCharacter));
-        cell.addItem(wearable);
+        try {
+            cell.addItem(wearable);
+        } catch (GameCellException e) {
+            throw new CannotDropWearableException("This cell already has an item.");
+        }
+        wearable.unapply(gameCharacter);
     }
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/GameModel.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/GameModel.java
@@ -7,6 +7,7 @@ import ru.spb.hse.roguelike.model.object.alive.AliveObject;
 import ru.spb.hse.roguelike.model.object.alive.ConfusedNonPlayerCharacter;
 import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
 import ru.spb.hse.roguelike.model.object.alive.NonPlayerCharacter;
+import ru.spb.hse.roguelike.model.object.items.CannotApplyFoodMultipleTimesException;
 import ru.spb.hse.roguelike.model.object.items.Item;
 import ru.spb.hse.roguelike.model.object.items.Wearable;
 
@@ -171,7 +172,7 @@ public class GameModel {
         return gameMap[point.getRow()][point.getCol()].hasItem();
     }
 
-    public void makeCharacterApplyItem() throws CannotPickItemException {
+    public void makeCharacterApplyItem() throws CannotPickItemException, CannotApplyFoodMultipleTimesException {
         GameCell cell = getCell(aliveObjectToPoint.get(gameCharacter));
         if (!cell.hasItem()) {
             throw new CannotPickItemException();

--- a/src/main/java/ru/spb/hse/roguelike/model/Generator.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/Generator.java
@@ -29,7 +29,7 @@ public class Generator {
     private final int maxRoomHeight = 7;
     private final int maxRoomWidth = 7;
     private final int indent = 1;
-    private final int maxFailedCreatingRoomAttemptCount = 10;
+    private final int maxFailedCreatingRoomAttemptCount = 30;
     private final int maxRegenerationCount = 1000;
     private final int maxCountMobsInRoom = 2;
     private final int numItems = 3;

--- a/src/main/java/ru/spb/hse/roguelike/model/map/GameCell.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/map/GameCell.java
@@ -68,4 +68,8 @@ public class GameCell {
     public void setGameMapCellType(@Nonnull GameMapCellType gameMapCellType) {
         this.gameMapCellType = gameMapCellType;
     }
+
+    public boolean isNonEmptyTypeAndHasNoObjects() {
+        return gameMapCellType != GameMapCellType.EMPTY && !hasAliveObject() && !hasItem();
+    }
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/map/GameCell.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/map/GameCell.java
@@ -24,20 +24,18 @@ public class GameCell {
         this.cellItem = cellItem;
     }
 
-    public boolean addItem(Item item) {
+    public void addItem(Item item) throws GameCellException {
         if (hasItem()) {
-            return false;
+            throw new GameCellException("This cell already has an item");
         }
         cellItem = item;
-        return true;
     }
 
-    public boolean addAliveObject(AliveObject object) {
+    public void addAliveObject(AliveObject object) throws GameCellException {
         if (hasAliveObject()) {
-            return false;
+            throw new GameCellException("This cell already has an alive object");
         }
         aliveObject = object;
-        return true;
     }
 
     public void removeAliveObject() {

--- a/src/main/java/ru/spb/hse/roguelike/model/map/GameCellException.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/map/GameCellException.java
@@ -1,0 +1,7 @@
+package ru.spb.hse.roguelike.model.map;
+
+public class GameCellException extends Exception {
+    public GameCellException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ru/spb/hse/roguelike/model/object/MeasurableCharacteristic.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/MeasurableCharacteristic.java
@@ -32,4 +32,7 @@ public class MeasurableCharacteristic {
         currentValue = Math.max(0, Math.min(maxValue, newValue));
     }
 
+    public void increaseCurrentValue(int diff) {
+        setCurrentValue(getCurrentValue() + diff);
+    }
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/object/alive/AliveObject.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/alive/AliveObject.java
@@ -30,12 +30,20 @@ public abstract class AliveObject {
         health.setMaxValue(x);
     }
 
+    public void increaseMaxHealth(int diff) {
+        health.increaseCurrentValue(diff);
+    }
+
     public int getCurrentPower() {
         return power.getCurrentValue();
     }
 
     public void setCurrentPower(int x) {
         power.setCurrentValue(x);
+    }
+
+    public void increaseCurrentPower(int diff) {
+        power.increaseCurrentValue(diff);
     }
 
     public int getMaxPower() {

--- a/src/main/java/ru/spb/hse/roguelike/model/object/alive/GameCharacter.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/alive/GameCharacter.java
@@ -1,12 +1,17 @@
 package ru.spb.hse.roguelike.model.object.alive;
 
 import ru.spb.hse.roguelike.model.object.MeasurableCharacteristic;
+import ru.spb.hse.roguelike.model.object.items.Item;
+import ru.spb.hse.roguelike.model.object.items.Wearable;
+
+import java.util.Stack;
 
 /**
  * Represents the game character (a character, that can be moved by player and use items)
  */
 public class GameCharacter extends AliveObject {
     private MeasurableCharacteristic foodFullness;
+    private Stack<Wearable> wearableStack = new Stack<>();
 
     public GameCharacter() {
         super(new MeasurableCharacteristic(10), new MeasurableCharacteristic(1));
@@ -23,5 +28,21 @@ public class GameCharacter extends AliveObject {
 
     public int getFoodFullness() {
         return foodFullness.getCurrentValue();
+    }
+
+    public void pushWearable(Wearable wearable) {
+        wearableStack.push(wearable);
+    }
+
+    public boolean hasWearable() {
+        return !wearableStack.empty();
+    }
+
+    public Wearable peekWearable() {
+        return wearableStack.peek();
+    }
+
+    public void popWearable() {
+        wearableStack.pop();
     }
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/CannotApplyFoodMultipleTimesException.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/CannotApplyFoodMultipleTimesException.java
@@ -1,0 +1,4 @@
+package ru.spb.hse.roguelike.model.object.items;
+
+public class CannotApplyFoodMultipleTimesException extends Throwable {
+}

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/DressWearable.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/DressWearable.java
@@ -1,0 +1,7 @@
+package ru.spb.hse.roguelike.model.object.items;
+
+public class DressWearable extends Wearable {
+    public DressWearable() {
+        super(2);
+    }
+}

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/DressWearable.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/DressWearable.java
@@ -1,5 +1,8 @@
 package ru.spb.hse.roguelike.model.object.items;
 
+/**
+ * Increases power for 2 point.
+ */
 public class DressWearable extends Wearable {
     public DressWearable() {
         super(2);

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/Food.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/Food.java
@@ -7,13 +7,18 @@ import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
  */
 public abstract class Food extends Item {
     private int foodFullnessImprover;
+    private boolean used = false;
 
     Food(int foodAmount) {
         foodFullnessImprover = foodAmount;
     }
 
     @Override
-    public void apply(GameCharacter gameCharacter) {
+    public void apply(GameCharacter gameCharacter) throws CannotApplyFoodMultipleTimesException {
+        if (used) {
+            throw new CannotApplyFoodMultipleTimesException();
+        }
         gameCharacter.setFoodFullness(gameCharacter.getFoodFullness() + foodFullnessImprover);
+        used = true;
     }
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/Food.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/Food.java
@@ -15,6 +15,5 @@ public abstract class Food extends Item {
     @Override
     public void apply(GameCharacter gameCharacter) {
         gameCharacter.setFoodFullness(gameCharacter.getFoodFullness() + foodFullnessImprover);
-        super.decreaseNumber();
     }
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/Item.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/Item.java
@@ -6,5 +6,5 @@ import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
  * An object that can't move on its own. The game character can use it to increase their characteristics.
  */
 public abstract class Item {
-    public abstract void apply(GameCharacter gameCharacter);
+    public abstract void apply(GameCharacter gameCharacter) throws CannotApplyFoodMultipleTimesException;
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/Item.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/Item.java
@@ -6,27 +6,5 @@ import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
  * An object that can't move on its own. The game character can use it to increase their characteristics.
  */
 public abstract class Item {
-    private int itemNumber;
-
-    Item() {
-        itemNumber = 1;
-    }
-
-    void increaseNumber() {
-        itemNumber++;
-    }
-
-    void decreaseNumber() {
-        itemNumber--;
-    }
-
-    boolean isEmpty() {
-        return itemNumber <= 0;
-    }
-
-    public int getItemNumber() {
-        return itemNumber;
-    }
-
     public abstract void apply(GameCharacter gameCharacter);
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/WaterFood.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/WaterFood.java
@@ -3,8 +3,8 @@ package ru.spb.hse.roguelike.model.object.items;
 /**
  * A very unfulfilling type of food with food value of 1. At least, it's healthy!
  */
-public class Water extends Food {
-    public Water() {
+public class WaterFood extends Food {
+    public WaterFood() {
         super(1);
     }
 }

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/Wearable.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/Wearable.java
@@ -1,0 +1,24 @@
+package ru.spb.hse.roguelike.model.object.items;
+
+import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
+
+public class Wearable extends Item {
+    // TODO: extend from an Item's superclass bc there can't be e.g. 2 dresses
+
+    private final int powerDiff;
+
+    public Wearable(int powerDiff) {
+        this.powerDiff = powerDiff;
+    }
+
+    @Override
+    public void apply(GameCharacter gameCharacter) {
+        gameCharacter.increaseCurrentPower(powerDiff);
+        gameCharacter.pushWearable(this);
+    }
+
+    public void unapply(GameCharacter gameCharacter) {
+        gameCharacter.increaseCurrentPower(-powerDiff);
+        gameCharacter.popWearable();
+    }
+}

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/Wearable.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/Wearable.java
@@ -6,8 +6,6 @@ import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
  * Increases power.
  */
 public abstract class Wearable extends Item {
-    // TODO: extend from an Item's superclass bc there can't be e.g. 2 dresses
-
     private final int powerDiff;
 
     public Wearable(int powerDiff) {

--- a/src/main/java/ru/spb/hse/roguelike/model/object/items/Wearable.java
+++ b/src/main/java/ru/spb/hse/roguelike/model/object/items/Wearable.java
@@ -2,7 +2,10 @@ package ru.spb.hse.roguelike.model.object.items;
 
 import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
 
-public class Wearable extends Item {
+/**
+ * Increases power.
+ */
+public abstract class Wearable extends Item {
     // TODO: extend from an Item's superclass bc there can't be e.g. 2 dresses
 
     private final int powerDiff;

--- a/src/main/java/ru/spb/hse/roguelike/view/Command.java
+++ b/src/main/java/ru/spb/hse/roguelike/view/Command.java
@@ -4,5 +4,5 @@ package ru.spb.hse.roguelike.view;
  * Command read from the input.
  */
 public enum Command {
-    LEFT, RIGHT, UP, DOWN, CONFUSE_MOBS
+    LEFT, RIGHT, UP, DOWN, CONFUSE_MOBS, APPLY_ITEM, DROP_WEARABLE
 }

--- a/src/main/java/ru/spb/hse/roguelike/view/TerminalView.java
+++ b/src/main/java/ru/spb/hse/roguelike/view/TerminalView.java
@@ -35,6 +35,7 @@ public class TerminalView extends View {
     private static final char PASSIVE_MOB_SYMBOL = 'P';
     private static final char COWARD_MOB_SYMBOL = 'C';
     private static final char RANDOM_MOB_SYMBOL = 'R';
+    private static final char ITEM_SYMBOL = '*';
     private static Map<GameMapCellType, Character> CELL_TYPE_TO_SYMBOL = new HashMap<GameMapCellType, Character>() {{
         put(GameMapCellType.ROOM, ROOM_SYMBOL);
         put(GameMapCellType.EMPTY, EMPTY_SYMBOL);
@@ -88,6 +89,8 @@ public class TerminalView extends View {
                 }
                 return ' ';
             }
+        } else if (gameCell.hasItem()) {
+            return ITEM_SYMBOL;
         }
         return CELL_TYPE_TO_SYMBOL.get(gameCell.getGameMapCellType());
     }
@@ -118,6 +121,10 @@ public class TerminalView extends View {
                     return Command.RIGHT;
                 case Tab:
                     return Command.CONFUSE_MOBS;
+                case Enter:
+                    return Command.APPLY_ITEM;
+                case Escape:
+                    return Command.DROP_WEARABLE;
             }
         } catch (IOException e) {
             System.out.println("Problems with parsing command");

--- a/src/test/java/ru/spb/hse/roguelike/controler/ControllerTest.java
+++ b/src/test/java/ru/spb/hse/roguelike/controler/ControllerTest.java
@@ -8,6 +8,7 @@ import ru.spb.hse.roguelike.model.MapGeneratorException;
 import ru.spb.hse.roguelike.model.UnknownObjectException;
 import ru.spb.hse.roguelike.model.map.GameCellException;
 import ru.spb.hse.roguelike.model.map.GameMapCellType;
+import ru.spb.hse.roguelike.model.object.items.CannotApplyFoodMultipleTimesException;
 import ru.spb.hse.roguelike.view.Command;
 import ru.spb.hse.roguelike.view.View;
 import ru.spb.hse.roguelike.view.ViewException;
@@ -22,7 +23,7 @@ import static org.mockito.Mockito.when;
 public class ControllerTest {
 
     @Test
-    public void moveLeftTest() throws MapGeneratorException, ViewException, UnknownObjectException, GameCellException {
+    public void moveLeftTest() throws MapGeneratorException, ViewException, UnknownObjectException, GameCellException, CannotApplyFoodMultipleTimesException {
         for (int k = 0; k < 1000; k++) {
             GameModel gameModel = new Generator().generateModel(3, 20, 25);
             gameModel.getCell(new Point(0, 3)).setGameMapCellType(GameMapCellType.ROOM);

--- a/src/test/java/ru/spb/hse/roguelike/controler/ControllerTest.java
+++ b/src/test/java/ru/spb/hse/roguelike/controler/ControllerTest.java
@@ -6,6 +6,7 @@ import ru.spb.hse.roguelike.model.GameModel;
 import ru.spb.hse.roguelike.model.Generator;
 import ru.spb.hse.roguelike.model.MapGeneratorException;
 import ru.spb.hse.roguelike.model.UnknownObjectException;
+import ru.spb.hse.roguelike.model.map.GameCellException;
 import ru.spb.hse.roguelike.model.map.GameMapCellType;
 import ru.spb.hse.roguelike.view.Command;
 import ru.spb.hse.roguelike.view.View;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.when;
 public class ControllerTest {
 
     @Test
-    public void moveLeftTest() throws MapGeneratorException, ViewException, UnknownObjectException {
+    public void moveLeftTest() throws MapGeneratorException, ViewException, UnknownObjectException, GameCellException {
         for (int k = 0; k < 1000; k++) {
             GameModel gameModel = new Generator().generateModel(3, 20, 25);
             gameModel.getCell(new Point(0, 3)).setGameMapCellType(GameMapCellType.ROOM);

--- a/src/test/java/ru/spb/hse/roguelike/model/GeneratorTest.java
+++ b/src/test/java/ru/spb/hse/roguelike/model/GeneratorTest.java
@@ -2,6 +2,7 @@ package ru.spb.hse.roguelike.model;
 
 import org.junit.Test;
 import ru.spb.hse.roguelike.Point;
+import ru.spb.hse.roguelike.model.map.GameCellException;
 import ru.spb.hse.roguelike.model.map.GameMapCellType;
 import ru.spb.hse.roguelike.model.object.alive.NonPlayerCharacter;
 
@@ -17,7 +18,7 @@ public class GeneratorTest {
     private final Generator generator = new Generator();
 
     @Test
-    public void testGenerateModelFromFile() throws FileNotFoundException, MapGeneratorException {
+    public void testGenerateModelFromFile() throws FileNotFoundException, MapGeneratorException, GameCellException {
         Function<Character, GameMapCellType> decoder = character -> {
             if (character == '.') {
                 return GameMapCellType.ROOM;
@@ -46,7 +47,7 @@ public class GeneratorTest {
     }
 
     @Test
-    public void testCountRooms() throws MapGeneratorException {
+    public void testCountRooms() throws MapGeneratorException, GameCellException {
         for (int x = 0; x < 1000; x++) {
             GameModel gameModel = generator.generateModel(3, 20, 25);
             int actualRoomCount = 0;
@@ -65,7 +66,7 @@ public class GeneratorTest {
     }
 
     @Test
-    public void testGenerateNPC() throws MapGeneratorException {
+    public void testGenerateNPC() throws MapGeneratorException, GameCellException {
         GameModel gameModel = generator.generateModel(3, 20, 25);
         int actualNPCCount = 0;
         for (int i = 0; i < 25; i++) {

--- a/src/test/java/ru/spb/hse/roguelike/model/map/GameCellTest.java
+++ b/src/test/java/ru/spb/hse/roguelike/model/map/GameCellTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import ru.spb.hse.roguelike.model.object.MeasurableCharacteristic;
 import ru.spb.hse.roguelike.model.object.alive.NonPlayerCharacter;
 import ru.spb.hse.roguelike.model.object.alive.NonPlayerCharacterStrategyType;
-import ru.spb.hse.roguelike.model.object.items.Water;
+import ru.spb.hse.roguelike.model.object.items.WaterFood;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -15,10 +15,10 @@ import static org.junit.Assert.assertTrue;
 public class GameCellTest {
 
     @Test
-    public void itemTest() {
+    public void itemTest() throws GameCellException {
         GameCell gameCell = new GameCell(GameMapCellType.ROOM, null, null);
         assertFalse(gameCell.hasItem());
-        gameCell.addItem(new Water());
+        gameCell.addItem(new WaterFood());
         assertTrue(gameCell.hasItem());
         gameCell.takeCellItem();
         assertFalse(gameCell.hasItem());

--- a/src/test/java/ru/spb/hse/roguelike/model/object/items/WaterTest.java
+++ b/src/test/java/ru/spb/hse/roguelike/model/object/items/WaterTest.java
@@ -6,19 +6,19 @@ import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests if WaterFood item changes game character characteristic.
+ * Tests if a WaterFood item changes game character's characteristic.
  */
 public class WaterTest {
 
     @Test
-    public void useTest() {
+    public void useTest() throws CannotApplyFoodMultipleTimesException {
         GameCharacter gameCharacter = new GameCharacter();
         gameCharacter.setFoodFullness(0);
         WaterFood water = new WaterFood();
-        water.increaseNumber();
         water.apply(gameCharacter);
         assertEquals(1, gameCharacter.getFoodFullness());
-        water.apply(gameCharacter);
+        WaterFood newWater = new WaterFood();
+        newWater.apply(gameCharacter);
         assertEquals(2, gameCharacter.getFoodFullness());
     }
 }

--- a/src/test/java/ru/spb/hse/roguelike/model/object/items/WaterTest.java
+++ b/src/test/java/ru/spb/hse/roguelike/model/object/items/WaterTest.java
@@ -6,7 +6,7 @@ import ru.spb.hse.roguelike.model.object.alive.GameCharacter;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests if Water item changes game character characteristic.
+ * Tests if WaterFood item changes game character characteristic.
  */
 public class WaterTest {
 
@@ -14,7 +14,7 @@ public class WaterTest {
     public void useTest() {
         GameCharacter gameCharacter = new GameCharacter();
         gameCharacter.setFoodFullness(0);
-        Water water = new Water();
+        WaterFood water = new WaterFood();
         water.increaseNumber();
         water.apply(gameCharacter);
         assertEquals(1, gameCharacter.getFoodFullness());


### PR DESCRIPTION
Добавлено взаимодействие с айтемами: айтем отображается на карте как `*`. Инвентарь — стэк айтемов. Поднять айтем: `Enter`, выкинуть айтем: `Esc`.

Существуют два абстрактных вида айтемов: `Food` увеличивает характеристику насыщенность, `Wearable` увеличивает силу. Сейчас айтем может находиться только в единственном количестве (раньше 1 айтем могу представлять из себя любое количество экземпляров данного айтема). `Food` можно применить один раз, `Wearable` можно снимать и надевать неограниченное количество раз, т.е. если айтем `Food`, то поднятие автоматически применяет еду, если айтем `Wearable`, то поднятие надевает айтем и добавлет его в инвентарь. Выкидывание айтема снимает последнюю надетый айтем, достает его из инвентаря и помещает на карту (клетка, в которой стоит персонаж должна быть свободной, иначе действие игнорируется).

На данный момент существуют следующие конктретные реализации: `WaterFood` (увеличивает насыщенность на 1) и `DressWearable` (увеличивает силу на 2).

TODO: Отображать характиристики в углу экрана и отображать строку-подсказку "Это платье. Чтобы надеть айтем, нажмите Enter".

TODO: Инвентарь является полем персонажа, из-за этого кажется возникает проблема неконсистентности (двойной ответственности) того, где находится айтем.

TODO: Исправить TODO в коде.